### PR TITLE
fix: 5 stability improvements for crash-proof VoxOps

### DIFF
--- a/Sources/VoxOpsCore/Audio/AudioManager.swift
+++ b/Sources/VoxOpsCore/Audio/AudioManager.swift
@@ -17,10 +17,16 @@ public final class AudioManager: @unchecked Sendable {
         recordedData = Data()
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
-        guard let recordingFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16000, channels: 1, interleaved: true) else { return }
+        guard let recordingFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16000, channels: 1, interleaved: true) else {
+            NSLog("[VoxOps] AudioManager: failed to create recording format")
+            return
+        }
         let busFormat = inputNode.outputFormat(forBus: 0)
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: busFormat) { [weak self] buffer, _ in
             guard let self else { return }
+            self.lock.lock()
+            guard self.isRecording else { self.lock.unlock(); return }
+            self.lock.unlock()
             if let converted = self.convert(buffer: buffer, to: recordingFormat) {
                 self.lock.lock()
                 self.recordedData.append(converted)
@@ -79,19 +85,31 @@ public final class AudioManager: @unchecked Sendable {
             let engine = AVAudioEngine()
             let inputNode = engine.inputNode
             let busFormat = inputNode.outputFormat(forBus: 0)
-            guard let recordingFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16000, channels: 1, interleaved: true) else { return }
+            guard let recordingFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16000, channels: 1, interleaved: true) else {
+                NSLog("[VoxOps] AudioManager: failed to create recording format during switchInput")
+                lock.lock(); isRecording = false; lock.unlock()
+                return
+            }
             inputNode.installTap(onBus: 0, bufferSize: 4096, format: busFormat) { [weak self] buffer, _ in
                 guard let self else { return }
+                self.lock.lock()
+                guard self.isRecording else { self.lock.unlock(); return }
+                self.lock.unlock()
                 if let converted = self.convert(buffer: buffer, to: recordingFormat) {
                     self.lock.lock()
                     self.recordedData.append(converted)
                     self.lock.unlock()
                 }
             }
-            try? engine.start()
-            lock.lock()
-            self.audioEngine = engine
-            lock.unlock()
+            do {
+                try engine.start()
+                lock.lock()
+                self.audioEngine = engine
+                lock.unlock()
+            } catch {
+                NSLog("[VoxOps] AudioManager: engine failed to start during switchInput: %@", error.localizedDescription)
+                lock.lock(); isRecording = false; lock.unlock()
+            }
         }
     }
 

--- a/Sources/VoxOpsCore/Hotkey/HotkeyManager.swift
+++ b/Sources/VoxOpsCore/Hotkey/HotkeyManager.swift
@@ -85,6 +85,9 @@ public final class HotkeyManager: @unchecked Sendable {
     }
 
     private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        lock.lock()
+        defer { lock.unlock() }
+
         let eventKeyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
         let modifierMask: CGEventFlags = [.maskCommand, .maskShift, .maskAlternate, .maskControl]
         let activeModifiers = event.flags.intersection(modifierMask)
@@ -95,7 +98,10 @@ public final class HotkeyManager: @unchecked Sendable {
             let requiredModifiers = voiceTrigger.cgEventFlags
             if !activeModifiers.contains(requiredModifiers) {
                 isVoiceActive = false
-                onKeyUp?()
+                let handler = onKeyUp
+                lock.unlock()
+                handler?()
+                lock.lock()
             }
             return Unmanaged.passUnretained(event)
         }
@@ -107,7 +113,10 @@ public final class HotkeyManager: @unchecked Sendable {
                 if !isAutoRepeat {
                     isToggleMode = !isToggleMode
                     isVoiceActive = isToggleMode
-                    onToggleListening?()
+                    let handler = onToggleListening
+                    lock.unlock()
+                    handler?()
+                    lock.lock()
                 }
                 return nil
             }
@@ -118,7 +127,10 @@ public final class HotkeyManager: @unchecked Sendable {
             let required = chat.cgEventFlags
             if required.isEmpty || activeModifiers.contains(required) {
                 if !isAutoRepeat {
-                    onChatToggle?()
+                    let handler = onChatToggle
+                    lock.unlock()
+                    handler?()
+                    lock.lock()
                 }
                 return nil
             }
@@ -143,13 +155,19 @@ public final class HotkeyManager: @unchecked Sendable {
             }
             if !isAutoRepeat {
                 isVoiceActive = true
-                onKeyDown?()
+                let handler = onKeyDown
+                lock.unlock()
+                handler?()
+                lock.lock()
             }
             return nil
         case .keyUp:
             guard isVoiceActive else { return Unmanaged.passUnretained(event) }
             isVoiceActive = false
-            onKeyUp?()
+            let handler = onKeyUp
+            lock.unlock()
+            handler?()
+            lock.lock()
             return nil
         default:
             return Unmanaged.passUnretained(event)

--- a/Sources/VoxOpsCore/Hotkey/HotkeyTrigger.swift
+++ b/Sources/VoxOpsCore/Hotkey/HotkeyTrigger.swift
@@ -26,14 +26,14 @@ public enum ModifierKey: String, Codable, CaseIterable, Comparable, Sendable {
     // Comparable — sort order for serialization: command, control, option, shift
     public static func < (lhs: ModifierKey, rhs: ModifierKey) -> Bool {
         let order: [ModifierKey] = [.command, .control, .option, .shift]
-        return order.firstIndex(of: lhs)! < order.firstIndex(of: rhs)!
+        return (order.firstIndex(of: lhs) ?? 0) < (order.firstIndex(of: rhs) ?? 0)
     }
 
     // Display sort order follows macOS convention: control, option, shift, command
     static let displayOrder: [ModifierKey] = [.control, .option, .shift, .command]
 
     var displaySortIndex: Int {
-        Self.displayOrder.firstIndex(of: self)!
+        Self.displayOrder.firstIndex(of: self) ?? 0
     }
 }
 

--- a/Sources/VoxOpsCore/Injection/AccessibilityInjector.swift
+++ b/Sources/VoxOpsCore/Injection/AccessibilityInjector.swift
@@ -21,7 +21,8 @@ public final class AccessibilityInjector: Sendable {
         guard CFGetTypeID(element) == AXUIElementGetTypeID() else {
             return InjectionResult(success: false, strategy: .accessibility, error: "Focused element is not an AXUIElement")
         }
-        let axElement = element as! AXUIElement
+        // swiftlint:disable:next force_cast — guarded by CFGetTypeID check above
+        let axElement = element as! AXUIElement // Safe: CFGetTypeID verified
 
         // Try inserting at selected text range
         var selectedRange: CFTypeRef?

--- a/Sources/VoxOpsCore/Pipeline/DictationFormatter.swift
+++ b/Sources/VoxOpsCore/Pipeline/DictationFormatter.swift
@@ -6,10 +6,11 @@ public struct DictationFormatter: TextFormatter {
     private let fillerPattern: NSRegularExpression
 
     public init() {
-        fillerPattern = try! NSRegularExpression(
+        // Pattern is hardcoded and known-valid; fallback to match-nothing if it ever fails
+        fillerPattern = (try? NSRegularExpression(
             pattern: #"(?i)(?:^|(?<=[.!?]\s))(um|uh|like|you know|basically|actually|so,)\s*"#,
             options: []
-        )
+        )) ?? NSRegularExpression()
     }
 
     public func format(_ text: String) -> String {

--- a/Sources/VoxOpsCore/STT/AppleSpeechBackend.swift
+++ b/Sources/VoxOpsCore/STT/AppleSpeechBackend.swift
@@ -68,14 +68,31 @@ public final class AppleSpeechBackend: STTBackend, @unchecked Sendable {
             request.requiresOnDeviceRecognition = true
         }
 
-        let result: SFSpeechRecognitionResult = try await withCheckedThrowingContinuation { cont in
-            recognizer.recognitionTask(with: request) { result, error in
-                if let error = error {
-                    cont.resume(throwing: error)
-                } else if let result = result, result.isFinal {
-                    cont.resume(returning: result)
+        let result: SFSpeechRecognitionResult = try await withThrowingTaskGroup(of: SFSpeechRecognitionResult.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { cont in
+                    let task = recognizer.recognitionTask(with: request) { result, error in
+                        if let error = error {
+                            cont.resume(throwing: error)
+                        } else if let result = result, result.isFinal {
+                            cont.resume(returning: result)
+                        }
+                    }
+                    // Cancel recognition if task is cancelled
+                    Task {
+                        await withTaskCancellationHandler { } onCancel: { task.cancel() }
+                    }
                 }
             }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 30_000_000_000) // 30s timeout
+                throw AppleSpeechError.recognizerUnavailable
+            }
+            guard let result = try await group.next() else {
+                throw AppleSpeechError.recognizerUnavailable
+            }
+            group.cancelAll()
+            return result
         }
 
         let elapsed = CFAbsoluteTimeGetCurrent() - startTime

--- a/Sources/VoxOpsCore/STT/MLXWhisperBackend.swift
+++ b/Sources/VoxOpsCore/STT/MLXWhisperBackend.swift
@@ -77,6 +77,7 @@ public final class MLXWhisperBackend: STTBackend, @unchecked Sendable {
                 do {
                     let fd = socket(AF_UNIX, SOCK_STREAM, 0)
                     guard fd >= 0 else { throw SidecarError.notRunning }
+                    defer { close(fd) }
                     var addr = sockaddr_un()
                     addr.sun_family = sa_family_t(AF_UNIX)
                     let pathBytes = sockPath.utf8CString
@@ -84,14 +85,18 @@ public final class MLXWhisperBackend: STTBackend, @unchecked Sendable {
                         let bound = ptr.withMemoryRebound(to: CChar.self, capacity: 104) { $0 }
                         for (i, byte) in pathBytes.enumerated() where i < 104 { bound[i] = byte }
                     }
-                    let addrLen = socklen_t(MemoryLayout.offset(of: \sockaddr_un.sun_path)! + sockPath.utf8.count + 1)
+                    guard let offset = MemoryLayout.offset(of: \sockaddr_un.sun_path) else { throw SidecarError.notRunning }
+                    let addrLen = socklen_t(offset + sockPath.utf8.count + 1)
                     let connectResult = withUnsafePointer(to: &addr) {
                         $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(fd, $0, addrLen) }
                     }
                     guard connectResult == 0 else { throw SidecarError.notRunning }
 
                     let message = tempFile.path + "\n"
-                    message.utf8CString.withUnsafeBufferPointer { _ = write(fd, $0.baseAddress!, message.utf8.count) }
+                    message.utf8CString.withUnsafeBufferPointer { buf in
+                        guard let base = buf.baseAddress else { return }
+                        _ = write(fd, base, message.utf8.count)
+                    }
 
                     var response = Data()
                     var buffer = [UInt8](repeating: 0, count: 4096)
@@ -101,7 +106,6 @@ public final class MLXWhisperBackend: STTBackend, @unchecked Sendable {
                         response.append(contentsOf: buffer[0..<n])
                         if buffer[0..<n].contains(UInt8(ascii: "\n")) { break }
                     }
-                    close(fd)
                     let line = String(data: response, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                     continuation.resume(returning: line)
                 } catch { continuation.resume(throwing: error) }

--- a/Sources/VoxOpsCore/Sidecar/SidecarProcess.swift
+++ b/Sources/VoxOpsCore/Sidecar/SidecarProcess.swift
@@ -57,27 +57,42 @@ public final class SidecarProcess: @unchecked Sendable {
         pipe.fileHandleForWriting.write(data)
     }
 
-    public func readLine() async throws -> String {
-        guard let pipe = stdoutPipe else { throw SidecarError.notRunning }
-        return try await withCheckedThrowingContinuation { continuation in
-            DispatchQueue.global().async {
-                let handle = pipe.fileHandleForReading
-                var accumulated = Data()
-                while true {
-                    let byte = handle.readData(ofLength: 1)
-                    if byte.isEmpty {
-                        let result = String(data: accumulated, encoding: .utf8) ?? ""
-                        continuation.resume(returning: result)
-                        return
+    public func readLine(timeoutSeconds: UInt64 = 30) async throws -> String {
+        lock.lock()
+        guard let pipe = stdoutPipe else { lock.unlock(); throw SidecarError.notRunning }
+        lock.unlock()
+        return try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { continuation in
+                    DispatchQueue.global().async {
+                        let handle = pipe.fileHandleForReading
+                        var accumulated = Data()
+                        while true {
+                            let byte = handle.readData(ofLength: 1)
+                            if byte.isEmpty {
+                                let result = String(data: accumulated, encoding: .utf8) ?? ""
+                                continuation.resume(returning: result)
+                                return
+                            }
+                            if byte.first == UInt8(ascii: "\n") {
+                                let result = String(data: accumulated, encoding: .utf8) ?? ""
+                                continuation.resume(returning: result)
+                                return
+                            }
+                            accumulated.append(byte)
+                        }
                     }
-                    if byte.first == UInt8(ascii: "\n") {
-                        let result = String(data: accumulated, encoding: .utf8) ?? ""
-                        continuation.resume(returning: result)
-                        return
-                    }
-                    accumulated.append(byte)
                 }
             }
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeoutSeconds * 1_000_000_000)
+                throw SidecarError.timeout
+            }
+            guard let result = try await group.next() else {
+                throw SidecarError.timeout
+            }
+            group.cancelAll()
+            return result
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove remaining force unwraps in HotkeyTrigger, DictationFormatter, MLXWhisperBackend
- Fix socket file descriptor leak in MLXWhisperBackend (fd now always closed via `defer`)
- Add 30s timeouts to AppleSpeechBackend transcription and SidecarProcess.readLine()
- Fix AudioManager silent state corruption (guard `isRecording` in audio tap, log format failures)
- Fix race conditions in HotkeyManager event tap callback (lock around all state reads/writes)

## Test plan
- [ ] Launch app, verify hotkey responds correctly (push-to-talk and toggle modes)
- [ ] Record and transcribe speech — verify no hangs
- [ ] Switch audio input device mid-recording
- [ ] Disconnect/reconnect network during OpenClaw session

🤖 Generated with [Claude Code](https://claude.com/claude-code)